### PR TITLE
Fix Gameplay Video

### DIFF
--- a/Docs/index.md
+++ b/Docs/index.md
@@ -5,7 +5,9 @@ nav_order: 1
 ---
 
 # TEMPTARE[^1]
-<iframe width="560" height="560" src="https://www.youtube.com/embed/iVY4b_V9NLc?si=vrloGeE0IZn09-kS?controls=0&autoplay=1&loop=1"></iframe>
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; border-radius: 8px;">
+  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;" src="https://www.youtube.com/embed/iVY4b_V9NLc?si=vrloGeE0IZn09-kS&controls=0&autoplay=1&mute=1&loop=1&playlist=iVY4b_V9NLc&modestbranding=1&rel=0" title="Temptare Gameplay Video" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+</div>
 
 ## Description
 Temptare is a Virtual Reality first person shooter that teaches gun safety through interactive gameplay. The player has the option to go through a training course where they must shoot enemy targets, avoid shooting friendly targets, and handle their gun with care. The player does not have to move themself through the training course. They are automatically moved through the course to reduce motion sickness. The player also has the option to get a hang of the controls on a shooting range. The game is designed to be both educational and entertaining, with the goal of improving gun safety knowledge and decision-making skills. The game was developed using Unity and C# and is intended to be played on a VR headset.


### PR DESCRIPTION
# Fix homepage video embed — autoplay, no border, no controls

## Summary

- Fixes a broken YouTube embed URL where a second `?` instead of `&` before the query parameters caused all of them (`controls`, `autoplay`, `loop`) to be silently ignored, leaving the full default YouTube player visible
- Adds `autoplay=1&mute=1` so the video starts playing on page load — `mute=1` is required because all modern browsers block unmuted autoplay without a prior user interaction
- Adds `loop=1&playlist=iVY4b_V9NLc` to keep the video playing continuously
- Sets `controls=0` to remove the YouTube control bar and play/share buttons
- Sets `modestbranding=1` and `rel=0` to suppress the YouTube logo and related-video end cards
- Removes the default iframe border and adds `border-radius: 8px` for a cleaner look
- Wraps the iframe in a `position: relative` / `padding-bottom: 56.25%` container so the embed scales responsively to any screen width at a fixed 16:9 aspect ratio

## Files changed

| File | Change |
|---|---|
| `Docs/index.md` | Replaced bare `<iframe>` with a responsive wrapper div; fixed URL params; added autoplay, mute, loop, controls=0, modestbranding, rel=0, border removal |
