### PR TITLE
Fix Video Embed: Square Aspect Ratio and Overlay to Hide YouTube UI

### DIFF
--- a/Docs/index.md
+++ b/Docs/index.md
@@ -5,8 +5,9 @@ nav_order: 1
 ---
 
 # TEMPTARE[^1]
-<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; border-radius: 8px;">
+<div style="position: relative; padding-bottom: 100%; height: 0; overflow: hidden; border-radius: 8px;">
   <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;" src="https://www.youtube.com/embed/iVY4b_V9NLc?si=vrloGeE0IZn09-kS&controls=0&autoplay=1&mute=1&loop=1&playlist=iVY4b_V9NLc&modestbranding=1&rel=0" title="Temptare Gameplay Video" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+  <div style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 1;"></div>
 </div>
 
 ## Description


### PR DESCRIPTION
# Fix homepage video embed — square aspect ratio and hidden YouTube UI

## Summary

- Changes the container `padding-bottom` from `56.25%` (16:9) to `100%` (1:1) to match the video's native square resolution, eliminating the black letterbox bars on the left and right sides
- Adds a transparent overlay `<div>` (`position: absolute`, full-size, `z-index: 1`) on top of the iframe to intercept hover events before they reach the YouTube player, preventing the control bar and title from appearing on hover
- The overlay also covers the white YouTube title bar (channel icon, title, "Share" button) that appears at the top of the embed on page load
- All existing behavior preserved — autoplay, muted, looping, no controls, no border, full-column responsive width

## Files changed

| File | Change |
|---|---|
| `Docs/index.md` | Changed `padding-bottom` to `100%` for square aspect ratio; added transparent overlay div to hide YouTube UI on load and hover |
