### PR TITLE
Fix Mobile Video Playback and Desktop Play/Pause Toggle

### DIFF
--- a/Docs/index.md
+++ b/Docs/index.md
@@ -6,9 +6,40 @@ nav_order: 1
 
 # TEMPTARE[^1]
 <div style="position: relative; padding-bottom: 100%; height: 0; overflow: hidden; border-radius: 8px;">
-  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;" src="https://www.youtube.com/embed/iVY4b_V9NLc?si=vrloGeE0IZn09-kS&controls=0&autoplay=1&mute=1&loop=1&playlist=iVY4b_V9NLc&modestbranding=1&rel=0" title="Temptare Gameplay Video" allow="autoplay; encrypted-media" allowfullscreen></iframe>
-  <div style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 1;"></div>
+  <iframe id="gameplay-video" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;" src="https://www.youtube.com/embed/iVY4b_V9NLc?si=vrloGeE0IZn09-kS&controls=0&autoplay=1&mute=1&loop=1&playlist=iVY4b_V9NLc&modestbranding=1&rel=0&playsinline=1&enablejsapi=1" title="Temptare Gameplay Video" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+  <div class="video-overlay" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 1; cursor: pointer;"></div>
 </div>
+<style>
+@media (pointer: coarse) {
+  .video-overlay { display: none; }
+}
+</style>
+<script>
+(function() {
+  var overlay = document.querySelector('.video-overlay');
+  var iframe = document.getElementById('gameplay-video');
+  if (!overlay || !iframe) return;
+
+  var playing = true;
+  var ytOrigin = 'https://www.youtube.com';
+
+  window.addEventListener('message', function(e) {
+    if (e.origin !== ytOrigin) return;
+    try {
+      var data = JSON.parse(e.data);
+      if (data.event === 'onStateChange') {
+        playing = data.info === 1 || data.info === 3;
+      }
+    } catch (_) {}
+  });
+
+  overlay.addEventListener('click', function() {
+    var cmd = playing ? 'pauseVideo' : 'playVideo';
+    iframe.contentWindow.postMessage(JSON.stringify({event: 'command', func: cmd, args: ''}), ytOrigin);
+    playing = !playing;
+  });
+})();
+</script>
 
 ## Description
 Temptare is a Virtual Reality first person shooter that teaches gun safety through interactive gameplay. The player has the option to go through a training course where they must shoot enemy targets, avoid shooting friendly targets, and handle their gun with care. The player does not have to move themself through the training course. They are automatically moved through the course to reduce motion sickness. The player also has the option to get a hang of the controls on a shooting range. The game is designed to be both educational and entertaining, with the goal of improving gun safety knowledge and decision-making skills. The game was developed using Unity and C# and is intended to be played on a VR headset.


### PR DESCRIPTION
# Fix Mobile Video Playback and Desktop Play/Pause Toggle

## Summary
- iOS blocked interaction entirely due to an overlay div covering the iframe; hide overlay on touch devices (`pointer: coarse`) so mobile users can tap to play
- Added `playsinline=1` so iOS plays the video inline rather than forcing fullscreen
- Wired overlay clicks on desktop to the YouTube iframe API (`enablejsapi=1` + `postMessage`) to toggle play/pause without exposing YouTube's control bar
- Synced `playing` state from YouTube's `onStateChange` messages to prevent desync when autoplay is blocked by the browser
- Scoped `postMessage` target to `https://www.youtube.com` instead of wildcard `'*'`
- Added null guard on DOM selectors and switched to `JSON.stringify` for the command payload

## Files Changed
| File | Change |
|---|---|
| `Docs/index.md` | Mobile overlay fix, desktop play/pause toggle via YouTube iframe API |